### PR TITLE
Fix loop on list while remove error

### DIFF
--- a/src/AsyncWebSocket.cpp
+++ b/src/AsyncWebSocket.cpp
@@ -1223,11 +1223,18 @@ void AsyncWebSocket::_cleanBuffers()
 {
   AsyncWebLockGuard l(_lock);
 
+  AsyncWebSocketMessageBuffer *remove = nullptr;
   for(AsyncWebSocketMessageBuffer * c: _buffers){
+    if(remove) {
+        _buffers.remove(remove);
+        remove = nullptr;
+    }
     if(c && c->canDelete()){
-        _buffers.remove(c);
+        remove = c;
     }
   }
+  if(remove)
+    _buffers.remove(remove);
 }
 
 

--- a/src/WebRequest.cpp
+++ b/src/WebRequest.cpp
@@ -178,11 +178,20 @@ void AsyncWebServerRequest::_onData(void *buf, size_t len){
 
 void AsyncWebServerRequest::_removeNotInterestingHeaders(){
   if (_interestingHeaders.containsIgnoreCase("ANY")) return; // nothing to do
-  for(const auto& header: _headers){
+
+  AsyncWebHeader *remove = nullptr;
+  for(const auto& header: _headers) {
+      if(remove) {
+        _headers.remove(remove);
+        remove = nullptr;
+      }
       if(!_interestingHeaders.containsIgnoreCase(header->name().c_str())){
-        _headers.remove(header);
+        remove = header;
       }
   }
+
+  if(remove)
+    _headers.remove(remove);
 }
 
 void AsyncWebServerRequest::_onPoll(){


### PR DESCRIPTION
This certainly isn't state-of-the-art fix, but it does highlight
the problem and makes the code runnable on ESP32 C3.

It was a bit nasty to track, as it's likely architecture dependant and although
it works on xtensa boards I have, it was crashing on riscv. Deleting the
element of the list that is assigned to the current iterator pointer results in
unexpected behavior which in this case results with dereferencing non-existent
address and guru meditation crash:

```
Guru Meditation Error: Core  0 panic'ed (Load access fault). Exception was unhandled.
```

The code modifies the loops slightly and delays removal to the next iteration
to avoid removing the iterator that is currently being used.

The right solution here would be to make the iterator more traditional and add
.remove() method to itself, but it requires more changes.

This hack provides a quick fix in case it's needed and in the meantime a proper
solution can be worked on.