### PR TITLE
Filename always with leading slash

### DIFF
--- a/library.json
+++ b/library.json
@@ -1,18 +1,22 @@
 {
-  "name":"ESP Async WebServer",
+  "name":"ESPAsyncWebServerAircoookie",
   "description":"Asynchronous HTTP and WebSocket Server Library for ESP8266 and ESP32 (Aircoookie fork)",
   "keywords":"http,async,websocket,webserver",
-  "authors":
-  {
-    "name": "Hristo Gochkov",
-    "maintainer": true
-  },
+  "authors": [
+    {
+      "name": "Hristo Gochkov"
+    },
+    {
+      "name": "Christian Schwinne",
+      "maintainer": true
+    }
+  ],
   "repository":
   {
     "type": "git",
-    "url": "https://github.com/me-no-dev/ESPAsyncWebServer.git"
+    "url": "https://github.com/Aircoookie/ESPAsyncWebServer.git"
   },
-  "version": "2.0.6",
+  "version": "2.0.7",
   "license": "LGPL-3.0",
   "frameworks": "arduino",
   "platforms": ["espressif8266", "espressif32"],

--- a/library.properties
+++ b/library.properties
@@ -1,9 +1,9 @@
 name=ESP Async WebServer
-version=2.0.6
+version=2.0.7
 author=Me-No-Dev
-maintainer=Me-No-Dev
+maintainer=Aircoookie
 sentence=Async Web Server for ESP8266 and ESP31B (Aircoookie fork)
 paragraph=Async Web Server for ESP8266 and ESP31B
 category=Other
-url=https://github.com/me-no-dev/ESPAsyncWebServer
+url=https://github.com/Aircoookie/ESPAsyncWebServer
 architectures=*

--- a/src/SPIFFSEditor.cpp
+++ b/src/SPIFFSEditor.cpp
@@ -354,13 +354,12 @@ void SPIFFSEditor::handleRequest(AsyncWebServerRequest *request){
         String fname = entry.name();
         if (fname.indexOf("wsec") == -1) {
           if (output != "[") output += ',';
-          output += "{\"type\":\"";
-          output += "file";
-          output += "\",\"name\":\"";
+          output += "{\"type\":\"file\",\"name\":\"";
+          if (fname[0] != '/') output += '/';
           output += fname;
           output += "\",\"size\":";
           output += String(entry.size());
-          output += "}";
+          output += '}';
         }
 #ifdef ESP32
         entry = dir.openNextFile();
@@ -371,7 +370,7 @@ void SPIFFSEditor::handleRequest(AsyncWebServerRequest *request){
 #ifdef ESP32
       dir.close();
 #endif
-      output += "]";
+      output += ']';
       request->send(200, "application/json", output);
       output = String();
     }


### PR DESCRIPTION
Some versions of the LittleFS library appear to prepend a leading `/` to the file name, others not. This unifies the string sent to the edit page to always have it present.