### PR TITLE
Move string literals to PROGMEM where possible

### DIFF
--- a/src/ESPAsyncWebServer.h
+++ b/src/ESPAsyncWebServer.h
@@ -357,7 +357,7 @@ class AsyncWebServerResponse {
     size_t _ackedLength;
     size_t _writtenLength;
     WebResponseState _state;
-    const char* _responseCodeToString(int code);
+    static const __FlashStringHelper* _responseCodeToString(int code);
 
   public:
     AsyncWebServerResponse();

--- a/src/WebResponses.cpp
+++ b/src/WebResponses.cpp
@@ -36,49 +36,49 @@ void* memchr(void* ptr, int ch, size_t count)
 /*
  * Abstract Response
  * */
-const char* AsyncWebServerResponse::_responseCodeToString(int code) {
+const __FlashStringHelper* AsyncWebServerResponse::_responseCodeToString(int code) {
   switch (code) {
-    case 100: return "Continue";
-    case 101: return "Switching Protocols";
-    case 200: return "OK";
-    case 201: return "Created";
-    case 202: return "Accepted";
-    case 203: return "Non-Authoritative Information";
-    case 204: return "No Content";
-    case 205: return "Reset Content";
-    case 206: return "Partial Content";
-    case 300: return "Multiple Choices";
-    case 301: return "Moved Permanently";
-    case 302: return "Found";
-    case 303: return "See Other";
-    case 304: return "Not Modified";
-    case 305: return "Use Proxy";
-    case 307: return "Temporary Redirect";
-    case 400: return "Bad Request";
-    case 401: return "Unauthorized";
-    case 402: return "Payment Required";
-    case 403: return "Forbidden";
-    case 404: return "Not Found";
-    case 405: return "Method Not Allowed";
-    case 406: return "Not Acceptable";
-    case 407: return "Proxy Authentication Required";
-    case 408: return "Request Time-out";
-    case 409: return "Conflict";
-    case 410: return "Gone";
-    case 411: return "Length Required";
-    case 412: return "Precondition Failed";
-    case 413: return "Request Entity Too Large";
-    case 414: return "Request-URI Too Large";
-    case 415: return "Unsupported Media Type";
-    case 416: return "Requested range not satisfiable";
-    case 417: return "Expectation Failed";
-    case 500: return "Internal Server Error";
-    case 501: return "Not Implemented";
-    case 502: return "Bad Gateway";
-    case 503: return "Service Unavailable";
-    case 504: return "Gateway Time-out";
-    case 505: return "HTTP Version not supported";
-    default:  return "";
+    case 100: return F("Continue");
+    case 101: return F("Switching Protocols");
+    case 200: return F("OK");
+    case 201: return F("Created");
+    case 202: return F("Accepted");
+    case 203: return F("Non-Authoritative Information");
+    case 204: return F("No Content");
+    case 205: return F("Reset Content");
+    case 206: return F("Partial Content");
+    case 300: return F("Multiple Choices");
+    case 301: return F("Moved Permanently");
+    case 302: return F("Found");
+    case 303: return F("See Other");
+    case 304: return F("Not Modified");
+    case 305: return F("Use Proxy");
+    case 307: return F("Temporary Redirect");
+    case 400: return F("Bad Request");
+    case 401: return F("Unauthorized");
+    case 402: return F("Payment Required");
+    case 403: return F("Forbidden");
+    case 404: return F("Not Found");
+    case 405: return F("Method Not Allowed");
+    case 406: return F("Not Acceptable");
+    case 407: return F("Proxy Authentication Required");
+    case 408: return F("Request Time-out");
+    case 409: return F("Conflict");
+    case 410: return F("Gone");
+    case 411: return F("Length Required");
+    case 412: return F("Precondition Failed");
+    case 413: return F("Request Entity Too Large");
+    case 414: return F("Request-URI Too Large");
+    case 415: return F("Unsupported Media Type");
+    case 416: return F("Requested range not satisfiable");
+    case 417: return F("Expectation Failed");
+    case 500: return F("Internal Server Error");
+    case 501: return F("Not Implemented");
+    case 502: return F("Bad Gateway");
+    case 503: return F("Service Unavailable");
+    case 504: return F("Gateway Time-out");
+    case 505: return F("HTTP Version not supported");
+    default:  return F("");
   }
 }
 
@@ -125,33 +125,35 @@ void AsyncWebServerResponse::addHeader(const String& name, const String& value){
 
 String AsyncWebServerResponse::_assembleHead(uint8_t version){
   if(version){
-    addHeader("Accept-Ranges","none");
+    addHeader(F("Accept-Ranges"),F("none"));
     if(_chunked)
-      addHeader("Transfer-Encoding","chunked");
+      addHeader(F("Transfer-Encoding"),F("chunked"));
   }
   String out = String();
   int bufSize = 300;
   char buf[bufSize];
 
-  snprintf(buf, bufSize, "HTTP/1.%d %d %s\r\n", version, _code, _responseCodeToString(_code));
+  snprintf_P(buf, bufSize, PSTR("HTTP/1.%d %d "), version, _code);
   out.concat(buf);
+  out.concat(_responseCodeToString(_code));
+  out.concat(F("\r\n"));
 
   if(_sendContentLength) {
-    snprintf(buf, bufSize, "Content-Length: %d\r\n", _contentLength);
+    snprintf_P(buf, bufSize, PSTR("Content-Length: %d\r\n"), _contentLength);
     out.concat(buf);
   }
   if(_contentType.length()) {
-    snprintf(buf, bufSize, "Content-Type: %s\r\n", _contentType.c_str());
+    snprintf_P(buf, bufSize, PSTR("Content-Type: %s\r\n"), _contentType.c_str());
     out.concat(buf);
   }
 
   for(const auto& header: _headers){
-    snprintf(buf, bufSize, "%s: %s\r\n", header->name().c_str(), header->value().c_str());
+    snprintf_P(buf, bufSize, PSTR("%s: %s\r\n"), header->name().c_str(), header->value().c_str());
     out.concat(buf);
   }
   _headers.free();
 
-  out.concat("\r\n");
+  out.concat(F("\r\n"));
   _headLength = out.length();
   return out;
 }
@@ -254,7 +256,7 @@ AsyncAbstractResponse::AsyncAbstractResponse(AwsTemplateProcessor callback): _ca
 }
 
 void AsyncAbstractResponse::_respond(AsyncWebServerRequest *request){
-  addHeader("Connection","close");
+  addHeader(F("Connection"),F("close"));
   _head = _assembleHead(request->version());
   _state = RESPONSE_HEADERS;
   _ack(request, 0, 0);
@@ -480,25 +482,25 @@ AsyncFileResponse::~AsyncFileResponse(){
 }
 
 void AsyncFileResponse::_setContentType(const String& path){
-  if (path.endsWith(".html")) _contentType = "text/html";
-  else if (path.endsWith(".htm")) _contentType = "text/html";
-  else if (path.endsWith(".css")) _contentType = "text/css";
-  else if (path.endsWith(".json")) _contentType = "application/json";
-  else if (path.endsWith(".js")) _contentType = "application/javascript";
-  else if (path.endsWith(".png")) _contentType = "image/png";
-  else if (path.endsWith(".gif")) _contentType = "image/gif";
-  else if (path.endsWith(".jpg")) _contentType = "image/jpeg";
-  else if (path.endsWith(".ico")) _contentType = "image/x-icon";
-  else if (path.endsWith(".svg")) _contentType = "image/svg+xml";
-  else if (path.endsWith(".eot")) _contentType = "font/eot";
-  else if (path.endsWith(".woff")) _contentType = "font/woff";
-  else if (path.endsWith(".woff2")) _contentType = "font/woff2";
-  else if (path.endsWith(".ttf")) _contentType = "font/ttf";
-  else if (path.endsWith(".xml")) _contentType = "text/xml";
-  else if (path.endsWith(".pdf")) _contentType = "application/pdf";
-  else if (path.endsWith(".zip")) _contentType = "application/zip";
-  else if(path.endsWith(".gz")) _contentType = "application/x-gzip";
-  else _contentType = "text/plain";
+  if (path.endsWith(F(".html"))) _contentType = F("text/html");
+  else if (path.endsWith(F(".htm"))) _contentType = F("text/html");
+  else if (path.endsWith(F(".css"))) _contentType = F("text/css");
+  else if (path.endsWith(F(".json"))) _contentType = F("application/json");
+  else if (path.endsWith(F(".js"))) _contentType = F("application/javascript");
+  else if (path.endsWith(F(".png"))) _contentType = F("image/png");
+  else if (path.endsWith(F(".gif"))) _contentType = F("image/gif");
+  else if (path.endsWith(F(".jpg"))) _contentType = F("image/jpeg");
+  else if (path.endsWith(F(".ico"))) _contentType = F("image/x-icon");
+  else if (path.endsWith(F(".svg"))) _contentType = F("image/svg+xml");
+  else if (path.endsWith(F(".eot"))) _contentType = F("font/eot");
+  else if (path.endsWith(F(".woff"))) _contentType = F("font/woff");
+  else if (path.endsWith(F(".woff2"))) _contentType = F("font/woff2");
+  else if (path.endsWith(F(".ttf"))) _contentType = F("font/ttf");
+  else if (path.endsWith(F(".xml"))) _contentType = F("text/xml");
+  else if (path.endsWith(F(".pdf"))) _contentType = F("application/pdf");
+  else if (path.endsWith(F(".zip"))) _contentType = F("application/zip");
+  else if(path.endsWith(F(".gz"))) _contentType = F("application/x-gzip");
+  else _contentType = F("text/plain");
 }
 
 AsyncFileResponse::AsyncFileResponse(FS &fs, const String& path, const String& contentType, bool download, AwsTemplateProcessor callback): AsyncAbstractResponse(callback){
@@ -507,7 +509,7 @@ AsyncFileResponse::AsyncFileResponse(FS &fs, const String& path, const String& c
 
   if(!download && !fs.exists(_path) && fs.exists(_path+".gz")){
     _path = _path+".gz";
-    addHeader("Content-Encoding", "gzip");
+    addHeader(F("Content-Encoding"), F("gzip"));
     _callback = nullptr; // Unable to process zipped templates
     _sendContentLength = true;
     _chunked = false;
@@ -527,20 +529,20 @@ AsyncFileResponse::AsyncFileResponse(FS &fs, const String& path, const String& c
 
   if(download) {
     // set filename and force download
-    snprintf(buf, sizeof (buf), "attachment; filename=\"%s\"", filename);
+    snprintf_P(buf, sizeof (buf), PSTR("attachment; filename=\"%s\""), filename);
   } else {
     // force rendering
-    snprintf(buf, sizeof (buf), "inline");
+    snprintf_P(buf, sizeof (buf), PSTR("inline"));
   }
-  addHeader("Content-Disposition", buf);
+  addHeader(F("Content-Disposition"), buf);
 }
 
 AsyncFileResponse::AsyncFileResponse(File content, const String& path, const String& contentType, bool download, AwsTemplateProcessor callback): AsyncAbstractResponse(callback){
   _code = 200;
   _path = path;
 
-  if(!download && String(content.name()).endsWith(".gz") && !path.endsWith(".gz")){
-    addHeader("Content-Encoding", "gzip");
+  if(!download && String(content.name()).endsWith(F(".gz")) && !path.endsWith(F(".gz"))){
+    addHeader(F("Content-Encoding"), F("gzip"));
     _callback = nullptr; // Unable to process gzipped templates
     _sendContentLength = true;
     _chunked = false;
@@ -559,11 +561,11 @@ AsyncFileResponse::AsyncFileResponse(File content, const String& path, const Str
   char* filename = (char*)path.c_str() + filenameStart;
 
   if(download) {
-    snprintf(buf, sizeof (buf), "attachment; filename=\"%s\"", filename);
+    snprintf_P(buf, sizeof (buf), PSTR("attachment; filename=\"%s\""), filename);
   } else {
-    snprintf(buf, sizeof (buf), "inline");
+    snprintf_P(buf, sizeof (buf), PSTR("inline"));
   }
-  addHeader("Content-Disposition", buf);
+  addHeader(F("Content-Disposition"), buf);
 }
 
 size_t AsyncFileResponse::_fillBuffer(uint8_t *data, size_t len){


### PR DESCRIPTION
Move the static response string text to PROGMEM.  This saves about 1k of RAM on ESP8266 systems.

Includes a small refactor of the AsyncFileResponse constructor to reduce duplication.