### PR TITLE
First round of fixes on v2.1.0 code

### DIFF
--- a/src/AsyncWebSocket.cpp
+++ b/src/AsyncWebSocket.cpp
@@ -30,7 +30,7 @@
 #endif
 
 #ifdef ASYNCWEBSERVER_DEBUG_TRACE
-#define DEBUG_PRINTFP(fmt, ...) Serial.printf_P(PSTR("[%d]{%d}" fmt "\n"), millis(), ESP.getFreeHeap(), ##__VA_ARGS__)
+#define DEBUG_PRINTFP(fmt, ...) Serial.printf_P(PSTR("[%u]{%d}" fmt "\n"), (unsigned) millis(), ESP.getFreeHeap(), ##__VA_ARGS__)
 #else
 #define DEBUG_PRINTFP(...)
 #endif

--- a/src/ContentTypes.cpp
+++ b/src/ContentTypes.cpp
@@ -7,7 +7,7 @@ static inline bool matches_p(const char* str, const char* progmem_str) {
 const __FlashStringHelper* contentTypeFor(const String& path) {
   // Find extension part of path
   auto idx = path.lastIndexOf('.');
-  if (idx < path.length()) {
+  if (idx >= 0) {
     auto ext_str = path.begin() + idx + 1;
 
     if (matches_p(ext_str, HTML_EXTENSION)) return FPSTR(CONTENT_TYPE_HTML);

--- a/src/DynamicBuffer.cpp
+++ b/src/DynamicBuffer.cpp
@@ -33,6 +33,12 @@ DynamicBuffer::DynamicBuffer(String&& s) : _data(nullptr), _len(s.length()) {
   }
 }
 
+DynamicBuffer::DynamicBuffer(const SharedBuffer& b) : DynamicBuffer(b.copy()) {};
+
+DynamicBuffer::DynamicBuffer(SharedBuffer&& b) : _data(nullptr), _len(0) {
+  if (b) *this = std::move(*b._buf);
+}
+
 String toString(DynamicBuffer buf) {  
   auto dbstr = DynamicBufferString(std::move(buf));
   return std::move(*static_cast<String*>(&dbstr));  // Move-construct the result string from dbstr

--- a/src/DynamicBuffer.cpp
+++ b/src/DynamicBuffer.cpp
@@ -8,11 +8,15 @@ namespace {
     // Inherit constructors
     using String::String;
     DynamicBufferString(String&& s) : String(std::move(s)) {};
-    DynamicBufferString(DynamicBuffer&& d) : String() {
+    DynamicBufferString(DynamicBuffer&& d) : String() {      
+      auto capacity = d.size() - 1;
+      auto buf = d.release();
+      auto len = strnlen(buf, capacity);
+      if (len == capacity) buf[len] = 0; // enforce null termination
       setSSO(false);
-      setCapacity(d.size() - 1);
-      setBuffer(d.release());
-      setLen(strlen(ptr.buff));
+      setBuffer(buf);
+      setCapacity(capacity);      
+      setLen(len);
     }
 
     // Special feature: releease the buffer to the caller without deallocating

--- a/src/DynamicBuffer.h
+++ b/src/DynamicBuffer.h
@@ -131,6 +131,9 @@ class BufferListPrint : public Print {
     size_t write(uint8_t c) {
       return this->write(&c, 1);
     }
+
+    bool valid() const { return _valid; };
+    explicit operator bool() const { return valid(); };
 };
 
 typedef BufferListPrint<DynamicBufferList> DynamicBufferListPrint;

--- a/src/DynamicBuffer.h
+++ b/src/DynamicBuffer.h
@@ -39,9 +39,11 @@ class DynamicBuffer {
 
   explicit operator bool() const { return (_data != nullptr) && (_len > 0); }
 
+  // Release the buffer without freeing it
+  char* release() { char* temp = _data; _data = nullptr; _len = 0; return temp; }
+
   // TODO, if it ever matters - resizing
 };
-
 
 // Same interface as DynamicBuffer, but with shared_ptr semantics: buffer is held until last copy releases it.
 class SharedBuffer {
@@ -64,6 +66,9 @@ class SharedBuffer {
   explicit operator bool() const { return _buf && *_buf; };
   DynamicBuffer copy() const { return *_buf; }; // Make a copy of the buffer
 };
+
+// Utility functions
+String toString(DynamicBuffer buf);   // Move a buffer in to a string.  Buffer will be moved if buf is an rvalue, copied otherwise.
 
 
 // DynamicBufferList - an RAII list of DynamicBuffers

--- a/src/DynamicBuffer.h
+++ b/src/DynamicBuffer.h
@@ -8,6 +8,9 @@
 #include <list>
 #include <utility>
 
+// Forward declaration
+class SharedBuffer;
+
 // The DynamicBuffer class holds a malloc() allocated heap buffer.
 // It's similar to std::vector<char>, but permits allocation failures without crashing the system.
 class DynamicBuffer {
@@ -23,6 +26,8 @@ class DynamicBuffer {
   DynamicBuffer(const char* buf, size_t len) : DynamicBuffer(len) { if (_data) memcpy(_data, buf, len); };
   explicit DynamicBuffer(const String& s) : DynamicBuffer(s.begin(), s.length()) {};
   explicit DynamicBuffer(String&&);  // Move string contents in to buffer if possible
+  DynamicBuffer(const SharedBuffer&);
+  DynamicBuffer(SharedBuffer&&);
   ~DynamicBuffer() { clear(); };
   
   // Move
@@ -48,6 +53,7 @@ class DynamicBuffer {
 // Same interface as DynamicBuffer, but with shared_ptr semantics: buffer is held until last copy releases it.
 class SharedBuffer {
   std::shared_ptr<DynamicBuffer> _buf;
+  friend class DynamicBuffer;
 
   public:
 
@@ -56,8 +62,8 @@ class SharedBuffer {
   SharedBuffer(const char* buf, size_t len) : _buf(std::make_shared<DynamicBuffer>(buf, len)) {};
   explicit SharedBuffer(const String& s) : _buf(std::make_shared<DynamicBuffer>(s)) {};
   explicit SharedBuffer(String&& s) : _buf(std::make_shared<DynamicBuffer>(std::move(s))) {};
-  explicit SharedBuffer(const DynamicBuffer &d) : _buf(std::make_shared<DynamicBuffer>(d)) {};
-  explicit SharedBuffer(DynamicBuffer&& d) : _buf(std::make_shared<DynamicBuffer>(std::move(d))) {};
+  SharedBuffer(const DynamicBuffer &d) : _buf(std::make_shared<DynamicBuffer>(d)) {};
+  SharedBuffer(DynamicBuffer&& d) : _buf(std::make_shared<DynamicBuffer>(std::move(d))) {};
 
   char* data() const { return _buf ? _buf->data() : nullptr; };
   size_t size() const { return _buf ? _buf->size() : 0U; };

--- a/src/WebRequest.cpp
+++ b/src/WebRequest.cpp
@@ -33,7 +33,7 @@ static const String SharedEmptyString = String();
 enum { PARSE_REQ_START, PARSE_REQ_HEADERS, PARSE_REQ_BODY, PARSE_REQ_END, PARSE_REQ_FAIL };
 
 #ifdef ASYNCWEBSERVER_DEBUG_TRACE
-#define DEBUG_PRINTFP(fmt, ...) Serial.printf_P(PSTR("[%d]{%d}" fmt "\n"), millis(), ESP.getFreeHeap(), ##__VA_ARGS__)
+#define DEBUG_PRINTFP(fmt, ...) Serial.printf_P(PSTR("[%u]{%d}" fmt "\n"), (unsigned) millis(), ESP.getFreeHeap(), ##__VA_ARGS__)
 #else
 #define DEBUG_PRINTFP(...)
 #endif

--- a/src/WebResponses.cpp
+++ b/src/WebResponses.cpp
@@ -23,7 +23,7 @@
 #include "cbuf.h"
 
 #ifdef ASYNCWEBSERVER_DEBUG_TRACE
-#define DEBUG_PRINTFP(fmt, ...) Serial.printf_P(PSTR("[%d]" fmt), millis(), ##__VA_ARGS__)
+#define DEBUG_PRINTFP(fmt, ...) Serial.printf_P(PSTR("[%u]" fmt), (unsigned) millis(), ##__VA_ARGS__)
 #else
 #define DEBUG_PRINTFP(...)
 #endif


### PR DESCRIPTION
First round of improvements past the initial 2.1.0 release.

- Fix ContentType file suffix handling when no extension available
- DynamicBuffer: Add additional move construction types
- AsyncWebSocket: Use DynamicBuffer instead of SharedBuffer to clarify ownership expectations