### PR TITLE
Add request queue with limits

### DIFF
--- a/library.json
+++ b/library.json
@@ -33,7 +33,7 @@
     {
       "owner": "willmmiles",      
       "name": "AsyncTCP",
-      "version": "^1.2.2",
+      "version": "^1.3.0",
       "platforms": "espressif32"
     },
     {

--- a/library.json
+++ b/library.json
@@ -33,7 +33,7 @@
     {
       "owner": "willmmiles",      
       "name": "AsyncTCP",
-      "version": "^1.2.1",
+      "version": "^1.2.2",
       "platforms": "espressif32"
     },
     {

--- a/library.json
+++ b/library.json
@@ -31,9 +31,9 @@
       "platforms": "espressif8266"
     },
     {
-      "owner": "me-no-dev",      
+      "owner": "willmmiles",      
       "name": "AsyncTCP",
-      "version": "^1.1.1",
+      "version": "^1.2.1",
       "platforms": "espressif32"
     },
     {

--- a/src/DynamicBuffer.cpp
+++ b/src/DynamicBuffer.cpp
@@ -43,6 +43,18 @@ DynamicBuffer::DynamicBuffer(SharedBuffer&& b) : _data(nullptr), _len(0) {
   if (b) *this = std::move(*b._buf);
 }
 
+size_t DynamicBuffer::resize(size_t s) {
+  if (_len != s) {
+    auto next = realloc(_data, s);
+    if (next) {
+      _data = reinterpret_cast<char*>(next);
+      _len = s;
+    }
+  }
+  
+  return _len;
+}
+
 String toString(DynamicBuffer buf) {  
   auto dbstr = DynamicBufferString(std::move(buf));
   return std::move(*static_cast<String*>(&dbstr));  // Move-construct the result string from dbstr

--- a/src/DynamicBuffer.h
+++ b/src/DynamicBuffer.h
@@ -166,6 +166,7 @@ class Walkable
   Walkable() : _left(0), _right(0) {};
   explicit Walkable(size_t len) : _buf(len), _left(0), _right(0) {};
   Walkable(const char* buf, size_t len) : _buf(buf, len), _left(0), _right(0) {};
+  Walkable(buffer_type&& buf) : _buf(std::move(buf)), _left(0), _right(0) {};
   explicit Walkable(const String& s) : _buf(s), _left(0), _right(0) {};
   explicit Walkable(String&& s) : _buf(std::move(s)), _left(0), _right(0) {};
 

--- a/src/DynamicBuffer.h
+++ b/src/DynamicBuffer.h
@@ -48,7 +48,8 @@ class DynamicBuffer {
   // Release the buffer without freeing it
   char* release() { char* temp = _data; _data = nullptr; _len = 0; return temp; }
 
-  // TODO, if it ever matters - resizing
+  // Resize the buffer.  Returns new size on success, current size on failure.
+  size_t resize(size_t);
 };
 
 // Same interface as DynamicBuffer, but with shared_ptr semantics: buffer is held until last copy releases it.

--- a/src/DynamicBuffer.h
+++ b/src/DynamicBuffer.h
@@ -217,7 +217,7 @@ class Walkable
 
   // Resize the underlying buffer storage, preserving contents
   // Returns new size on success, current size on failure.
-  size_t realloc(size_t s) {
+  size_t reallocate(size_t s) {
     if (s <= size()) {
       auto new_buf = buffer_type(data(), s);
       if (new_buf) {

--- a/src/DynamicBuffer.h
+++ b/src/DynamicBuffer.h
@@ -24,20 +24,21 @@ class DynamicBuffer {
   DynamicBuffer() : _data(nullptr), _len(0) {};
   explicit DynamicBuffer(size_t len) : _data(len ? reinterpret_cast<char*>(malloc(len)): nullptr), _len(_data ? len : 0) {};
   DynamicBuffer(const char* buf, size_t len) : DynamicBuffer(len) { if (_data) memcpy(_data, buf, len); };
-  explicit DynamicBuffer(const String& s) : DynamicBuffer(s.begin(), s.length()) {};
-  explicit DynamicBuffer(String&&);  // Move string contents in to buffer if possible
-  DynamicBuffer(const SharedBuffer&);
-  DynamicBuffer(SharedBuffer&&);
+
   ~DynamicBuffer() { clear(); };
   
   // Move
   DynamicBuffer(DynamicBuffer&& d) : _data(d._data), _len(d._len) { d._data = nullptr; d._len = 0; };
   DynamicBuffer& operator=(DynamicBuffer&& d) { std::swap(_data, d._data); std::swap(_len, d._len); return *this; };
+  DynamicBuffer(SharedBuffer&&);       // Move data, leaving shared buffer empty
+  explicit DynamicBuffer(String&&);    // Move string contents in to buffer if possible  
 
   // Copy
   DynamicBuffer(const DynamicBuffer& d) : DynamicBuffer(d._data, d._len) {};  // copy
   DynamicBuffer& operator=(const DynamicBuffer& d) { *this = DynamicBuffer(d); return *this; }; // use move to copy
-
+  DynamicBuffer(const SharedBuffer&);   // Copy data
+  explicit DynamicBuffer(const String& s) : DynamicBuffer(s.begin(), s.length()) {};
+  
   // Accessors
   char* data() const { return _data; };
   size_t size() const { return _len; };

--- a/src/DynamicBuffer.h
+++ b/src/DynamicBuffer.h
@@ -41,6 +41,7 @@ class DynamicBuffer {
   // Accessors
   char* data() const { return _data; };
   size_t size() const { return _len; };
+  char& operator[](ptrdiff_t p) const { return *(_data + p); };
 
   explicit operator bool() const { return (_data != nullptr) && (_len > 0); }
 
@@ -67,6 +68,7 @@ class SharedBuffer {
 
   char* data() const { return _buf ? _buf->data() : nullptr; };
   size_t size() const { return _buf ? _buf->size() : 0U; };
+  char& operator[](ptrdiff_t p) const { return *(data() + p); };
   void clear() { _buf.reset(); };
 
   explicit operator bool() const { return _buf && *_buf; };

--- a/src/ESPAsyncWebServer.h
+++ b/src/ESPAsyncWebServer.h
@@ -442,14 +442,15 @@ class AsyncWebServer {
 
     void reset(); //remove all writers and handlers, with onNotFound/onFileUpload/onRequestBody 
 
+    void processQueue();  // Attempt to execute any queued requests, if possible
     size_t queueLength() { return _requestQueue.length(); };
+    
     void dumpStatus();  // debug
   
     void _handleDisconnect(AsyncWebServerRequest *request);
     void _attachHandler(AsyncWebServerRequest *request);
     void _rewriteRequest(AsyncWebServerRequest *request);
-
-    void _processQueue();
+    
     void _dequeue(AsyncWebServerRequest *request);
     void _defer(AsyncWebServerRequest *request);
 };

--- a/src/ESPAsyncWebServer.h
+++ b/src/ESPAsyncWebServer.h
@@ -372,6 +372,7 @@ class AsyncWebServerResponse {
     size_t _writtenLength; // size of data written to client
     WebResponseState _state;
     static const __FlashStringHelper* _responseCodeToString(int code);
+    friend class AsyncWebServer;
 
   public:
     AsyncWebServerResponse();
@@ -440,6 +441,7 @@ class AsyncWebServer {
     void reset(); //remove all writers and handlers, with onNotFound/onFileUpload/onRequestBody 
 
     size_t queueLength() { return _requestQueue.length(); };
+    void dumpStatus();  // debug
   
     void _handleDisconnect(AsyncWebServerRequest *request);
     void _attachHandler(AsyncWebServerRequest *request);

--- a/src/ESPAsyncWebServer.h
+++ b/src/ESPAsyncWebServer.h
@@ -410,9 +410,10 @@ class AsyncWebServer {
     LinkedList<AsyncWebHandler*> _handlers;    
     AsyncCallbackWebHandler* _catchAllHandler;
 #ifdef ASYNCWEBSERVER_NEEDS_MUTEX    
-    std::recursive_mutex _mutex;
+    std::mutex _mutex;
 #endif
     LinkedList<AsyncWebServerRequest*> _requestQueue;
+    bool _queueActive;
     
 
   public:

--- a/src/ESPAsyncWebServer.h
+++ b/src/ESPAsyncWebServer.h
@@ -465,7 +465,8 @@ class AsyncWebServer {
     void reset(); //remove all writers and handlers, with onNotFound/onFileUpload/onRequestBody 
 
     // Queue interface
-    size_t queueLength() { return _requestQueue.length(); };
+    size_t numClients();  // Number of active clients, active and pending
+    size_t queueLength(); // Number of queued clients
     const AsyncWebServerQueueLimits& getQueueLimits() { return _queueLimits; };
     void setQueueLimits(const AsyncWebServerQueueLimits& limits);
     void printStatus(Print&);  // Write queue status in human-readable format

--- a/src/ESPAsyncWebServer.h
+++ b/src/ESPAsyncWebServer.h
@@ -256,6 +256,8 @@ class AsyncWebServerRequest {
     AsyncWebServerResponse *beginResponse_P(int code, const String& contentType, const uint8_t * content, size_t len, AwsTemplateProcessor callback=nullptr);
     AsyncWebServerResponse *beginResponse_P(int code, const String& contentType, PGM_P content, AwsTemplateProcessor callback=nullptr);
 
+    void deferResponse();  // Move to the back of the queue
+
     size_t headers() const;                     // get header count
     bool hasHeader(const String& name) const;   // check if header exists
     bool hasHeader(const __FlashStringHelper * data) const;   // check if header exists
@@ -448,6 +450,7 @@ class AsyncWebServer {
     void _rewriteRequest(AsyncWebServerRequest *request);
     bool _isQueued(AsyncWebServerRequest *request);
     void _dequeue(AsyncWebServerRequest *request);
+    void _defer(AsyncWebServerRequest *request);
 };
 
 class DefaultHeaders {

--- a/src/ESPAsyncWebServer.h
+++ b/src/ESPAsyncWebServer.h
@@ -429,7 +429,6 @@ class AsyncWebServer {
     LinkedList<AsyncWebServerRequest*> _requestQueue;
     bool _queueActive;
     
-
   public:
     AsyncWebServer(IPAddress addr, uint16_t port);
     AsyncWebServer(uint16_t port);
@@ -465,10 +464,12 @@ class AsyncWebServer {
 
     void reset(); //remove all writers and handlers, with onNotFound/onFileUpload/onRequestBody 
 
-    void processQueue();  // Attempt to execute any queued requests, if possible
+    // Queue interface
     size_t queueLength() { return _requestQueue.length(); };
-
+    const AsyncWebServerQueueLimits& getQueueLimits() { return _queueLimits; };
+    void setQueueLimits(const AsyncWebServerQueueLimits& limits);
     void printStatus(Print&);  // Write queue status in human-readable format
+    void processQueue();  // Consider the current queue state against the limits; may retry deferred handlers.
   
     void _handleDisconnect(AsyncWebServerRequest *request);
     void _attachHandler(AsyncWebServerRequest *request);

--- a/src/ESPAsyncWebServer.h
+++ b/src/ESPAsyncWebServer.h
@@ -196,8 +196,8 @@ class AsyncWebServerRequest {
     void _parseMultipartPostByte(uint8_t data, bool last);
     void _addGetParams(const String& params);
     
-    void _setupHandler();
-    void _onReady();  // called when the queue permits this request to run
+    void _requestReady();
+    void _handleRequest();  // called when the queue permits this request to run
 
     void _handleUploadStart();
     void _handleUploadByte(uint8_t data, bool last);
@@ -407,11 +407,11 @@ class AsyncWebServer {
     LinkedList<AsyncWebHandler*> _handlers;    
     AsyncCallbackWebHandler* _catchAllHandler;
     LinkedList<AsyncWebServerRequest*> _requestQueue;
-    size_t _parallelRequests, _maxRequests;
+    size_t _reqHeapUsage, _minHeap;
 
   public:
-    AsyncWebServer(IPAddress addr, uint16_t port, size_t parallelRequests = 0, size_t maxRequests = 0);
-    AsyncWebServer(uint16_t port, size_t parallelRequests = 0, size_t maxRequests = 0);
+    AsyncWebServer(IPAddress addr, uint16_t port, size_t reqHeapUsage = 0, size_t minHeap = 0);
+    AsyncWebServer(uint16_t port, size_t reqHeapUsage = 0, size_t minHeap = 0);
     ~AsyncWebServer();
 
     void begin();
@@ -448,7 +448,8 @@ class AsyncWebServer {
     void _handleDisconnect(AsyncWebServerRequest *request);
     void _attachHandler(AsyncWebServerRequest *request);
     void _rewriteRequest(AsyncWebServerRequest *request);
-    bool _isQueued(AsyncWebServerRequest *request);
+
+    void _processQueue();
     void _dequeue(AsyncWebServerRequest *request);
     void _defer(AsyncWebServerRequest *request);
 };

--- a/src/ESPAsyncWebServer.h
+++ b/src/ESPAsyncWebServer.h
@@ -452,7 +452,7 @@ class AsyncWebServer {
     void processQueue();  // Attempt to execute any queued requests, if possible
     size_t queueLength() { return _requestQueue.length(); };
 
-    void dumpStatus();  // debug
+    void printStatus(Print&);  // Write queue status in human-readable format
   
     void _handleDisconnect(AsyncWebServerRequest *request);
     void _attachHandler(AsyncWebServerRequest *request);

--- a/src/ESPAsyncWebServer.h
+++ b/src/ESPAsyncWebServer.h
@@ -395,6 +395,20 @@ class AsyncWebServerResponse {
 };
 
 /*
+ * Queue limit structure for Server
+ * 
+ * Any value set to 0 indicates no limit.
+ * */
+struct AsyncWebServerQueueLimits {
+  // Count limits
+  size_t nParallel;   // Permit up to this number of active parallel requests.
+  size_t nMax;        // Permit up to this number of active + queued requests - send 503 otherwise.
+  // Heap limits  
+  size_t queueHeapRequired;     // Require at least this much free heap before queuing a new request, otherwise send a 503.
+  size_t requestHeapRequired;   // Require at least this much free heap before handling a new request, except if no requests are active.  
+};
+
+/*
  * SERVER :: One instance
  * */
 
@@ -404,7 +418,7 @@ typedef std::function<void(AsyncWebServerRequest *request, uint8_t *data, size_t
 
 class AsyncWebServer {
   protected:
-    size_t _reqHeapUsage, _minHeap;
+    AsyncWebServerQueueLimits _queueLimits;
     AsyncServer _server;
     LinkedList<AsyncWebRewrite*> _rewrites;
     LinkedList<AsyncWebHandler*> _handlers;    
@@ -417,8 +431,10 @@ class AsyncWebServer {
     
 
   public:
-    AsyncWebServer(IPAddress addr, uint16_t port, size_t reqHeapUsage = 0, size_t minHeap = 0);
-    AsyncWebServer(uint16_t port, size_t reqHeapUsage = 0, size_t minHeap = 0);
+    AsyncWebServer(IPAddress addr, uint16_t port);
+    AsyncWebServer(uint16_t port);
+    AsyncWebServer(IPAddress addr, uint16_t port, const AsyncWebServerQueueLimits& limits);
+    AsyncWebServer(uint16_t port, const AsyncWebServerQueueLimits& limits);
     ~AsyncWebServer();
 
     void begin();

--- a/src/WebRequest.cpp
+++ b/src/WebRequest.cpp
@@ -30,7 +30,7 @@ static const String SharedEmptyString = String();
 
 #define __is_param_char(c) ((c) && ((c) != '{') && ((c) != '[') && ((c) != '&') && ((c) != '='))
 
-enum { PARSE_REQ_START, PARSE_REQ_HEADERS, PARSE_REQ_BODY, PARSE_REQ_END, PARSE_REQ_FAIL, PARSE_REQ_QUEUED };
+enum { PARSE_REQ_START, PARSE_REQ_HEADERS, PARSE_REQ_BODY, PARSE_REQ_END=100, PARSE_REQ_FAIL, PARSE_REQ_QUEUED=200, PARSE_REQ_DEFERRED=201 };
 
 #ifdef ASYNCWEBSERVER_DEBUG_TRACE
 #define DEBUG_PRINTFP(fmt, ...) Serial.printf_P(PSTR("[%u]{%d}" fmt "\n"), (unsigned) millis(), ESP.getFreeHeap(), ##__VA_ARGS__)
@@ -181,10 +181,7 @@ void AsyncWebServerRequest::_onData(void *buf, size_t len){
       }
     }
     if(_parsedLength == _contentLength){
-      _parseState = PARSE_REQ_END;
-      //check if authenticated before calling handleRequest and request auth instead
-      if(_handler) _handler->handleRequest(this);
-      else send(501);
+      _requestReady();
     }
   }
   break;
@@ -204,7 +201,9 @@ void AsyncWebServerRequest::_removeNotInterestingHeaders(){
 
 void AsyncWebServerRequest::_onPoll(){
   //os_printf("p\n");
-  if(_response != NULL && _client != NULL && _client->canSend() && !_response->_finished()){
+  if (_parseState == PARSE_REQ_QUEUED) {
+    _server->_processQueue();
+  } else if(_response != NULL && _client != NULL && _client->canSend() && !_response->_finished()){
     _response->_ack(this, 0, 0);
   }
 }
@@ -581,57 +580,47 @@ void AsyncWebServerRequest::_parseLine(){
   if(_parseState == PARSE_REQ_HEADERS){
     if(!_temp.length()){
       //end of headers
-      if (_handler) {
-        // A handler was already attached by the server's queue management
-        _parseState = PARSE_REQ_END;
-        _handler->handleRequest(this);
-        return;
-      }
-
       _server->_rewriteRequest(this);
-      DEBUG_PRINTFP("(%d) WR ready %s", (intptr_t) this, url().c_str());
-      // If queue is full, hold this request
-      // Note we can't hold uploads as there's no way to stop the client from sending
-      if (!_server->_isQueued(this) || (_contentLength && !_expectingContinue)) {
-        _setupHandler();
-      } else {
-        _parseState = PARSE_REQ_QUEUED;
-      }
+      _server->_attachHandler(this);
+      _removeNotInterestingHeaders();
 
+      if(_expectingContinue){
+        const static char response[] PROGMEM = "HTTP/1.1 100 Continue\r\n\r\n";
+          char response_stack[sizeof(response)];  // stack, so we can pull it out of flash memory
+          memcpy_P(response_stack, response, sizeof(response));
+        _client->write(response_stack, os_strlen(response_stack));
+      }    
+
+      //check handler for authentication
+      if(_contentLength){
+        _parseState = PARSE_REQ_BODY;
+      } else {
+        _requestReady();
+      }      
     } else _parseReqHeader();
   }
 }
 
-void AsyncWebServerRequest::_setupHandler() {
-    DEBUG_PRINTFP("(%d) WR adding handler", (intptr_t) this);
-    _server->_attachHandler(this);
-    _removeNotInterestingHeaders();
-    if(_expectingContinue){
-      const static char response[] PROGMEM = "HTTP/1.1 100 Continue\r\n\r\n";
-        char response_stack[sizeof(response)];  // stack, so we can pull it out of flash memory
-        memcpy_P(response_stack, response, sizeof(response));
-      _client->write(response_stack, os_strlen(response_stack));
+void AsyncWebServerRequest::_requestReady() {
+    //check if authenticated before calling handleRequest and request auth instead
+    DEBUG_PRINTFP("(%d) WR handler ready %s", (intptr_t) this, url().c_str());
+    if(_handler) {
+      _parseState = PARSE_REQ_QUEUED;
+      _server->_processQueue();
     }
-    //check handler for authentication
-    if(_contentLength){
-      _parseState = PARSE_REQ_BODY;
-    } else {
+    else {
       _parseState = PARSE_REQ_END;
-      if(_handler) _handler->handleRequest(this);
-      else send(501);
+      send(501);
     }
 }
 
-void AsyncWebServerRequest::_onReady() {
-    if (_parseState == PARSE_REQ_QUEUED) {
-      _setupHandler();
-    } else if ((_parseState == PARSE_REQ_END) && !_response) {
-        DEBUG_PRINTFP("(%d) WR retrying handleRequest", (intptr_t) this);
-        // Shouldn't be possible to land here without a handler
-        if(_handler) _handler->handleRequest(this);
-        else send(501);
-    }
-}
+void AsyncWebServerRequest::_handleRequest() {
+  // Shouldn't be possible to land here without a handler
+  assert(_handler);
+  DEBUG_PRINTFP("(%d) WR handler running", (intptr_t) this);
+  _parseState = PARSE_REQ_END;
+  _handler->handleRequest(this);
+};
 
 size_t AsyncWebServerRequest::headers() const{
   return _headers.length();
@@ -1058,5 +1047,6 @@ bool AsyncWebServerRequest::isExpectedRequestedConnType(RequestedConnectionType 
 void AsyncWebServerRequest::deferResponse() {
   // Ask the server to put us on the back of the queue
   DEBUG_PRINTFP("(%d) WR defer", (intptr_t) this);
-  _server->_defer(this);
+  _parseState = PARSE_REQ_DEFERRED;
+  // Queue processing loop will handle it from here
 }

--- a/src/WebRequest.cpp
+++ b/src/WebRequest.cpp
@@ -30,7 +30,7 @@ static const String SharedEmptyString = String();
 
 #define __is_param_char(c) ((c) && ((c) != '{') && ((c) != '[') && ((c) != '&') && ((c) != '='))
 
-enum { PARSE_REQ_START, PARSE_REQ_HEADERS, PARSE_REQ_BODY, PARSE_REQ_END, PARSE_REQ_FAIL };
+enum { PARSE_REQ_START, PARSE_REQ_HEADERS, PARSE_REQ_BODY, PARSE_REQ_END, PARSE_REQ_FAIL, PARSE_REQ_QUEUED };
 
 #ifdef ASYNCWEBSERVER_DEBUG_TRACE
 #define DEBUG_PRINTFP(fmt, ...) Serial.printf_P(PSTR("[%u]{%d}" fmt "\n"), (unsigned) millis(), ESP.getFreeHeap(), ##__VA_ARGS__)
@@ -105,6 +105,8 @@ AsyncWebServerRequest::~AsyncWebServerRequest(){
   if(_tempFile){
     _tempFile.close();
   }
+
+  _server->_dequeue(this);
   
   DEBUG_PRINTFP("(%d) WR destructed", (intptr_t)this);
 }
@@ -581,24 +583,41 @@ void AsyncWebServerRequest::_parseLine(){
       //end of headers
       _server->_rewriteRequest(this);
       DEBUG_PRINTFP("(%d) WR ready %s", (intptr_t) this, url().c_str());
-      _server->_attachHandler(this);
-      _removeNotInterestingHeaders();
-      if(_expectingContinue){
-        const static char response[] PROGMEM = "HTTP/1.1 100 Continue\r\n\r\n";
-        char response_stack[sizeof(response)];  // stack, so we can pull it out of flash memory
-        memcpy_P(response_stack, response, sizeof(response));
-        _client->write(response_stack, os_strlen(response_stack));
-      }
-      //check handler for authentication
-      if(_contentLength){
-        _parseState = PARSE_REQ_BODY;
+      // If queue is full, hold this request
+      // Note we can't hold uploads as there's no way to stop the client from sending
+      if (!_server->_isQueued(this) || (_contentLength && !_expectingContinue)) {
+        _setupHandler();
       } else {
-        _parseState = PARSE_REQ_END;
-        if(_handler) _handler->handleRequest(this);
-        else send(501);
+        _parseState = PARSE_REQ_QUEUED;
       }
+
     } else _parseReqHeader();
   }
+}
+
+void AsyncWebServerRequest::_setupHandler() {
+    _server->_attachHandler(this);
+    _removeNotInterestingHeaders();
+    if(_expectingContinue){
+      const static char response[] PROGMEM = "HTTP/1.1 100 Continue\r\n\r\n";
+        char response_stack[sizeof(response)];  // stack, so we can pull it out of flash memory
+        memcpy_P(response_stack, response, sizeof(response));
+      _client->write(response_stack, os_strlen(response_stack));
+    }
+    //check handler for authentication
+    if(_contentLength){
+      _parseState = PARSE_REQ_BODY;
+    } else {
+      _parseState = PARSE_REQ_END;
+      if(_handler) _handler->handleRequest(this);
+      else send(501);
+    }
+}
+
+void AsyncWebServerRequest::_onReady() {
+    if (_parseState == PARSE_REQ_QUEUED) {
+      _setupHandler();
+    } 
 }
 
 size_t AsyncWebServerRequest::headers() const{

--- a/src/WebRequest.cpp
+++ b/src/WebRequest.cpp
@@ -581,6 +581,13 @@ void AsyncWebServerRequest::_parseLine(){
   if(_parseState == PARSE_REQ_HEADERS){
     if(!_temp.length()){
       //end of headers
+      if (_handler) {
+        // A handler was already attached by the server's queue management
+        _parseState = PARSE_REQ_END;
+        _handler->handleRequest(this);
+        return;
+      }
+
       _server->_rewriteRequest(this);
       DEBUG_PRINTFP("(%d) WR ready %s", (intptr_t) this, url().c_str());
       // If queue is full, hold this request

--- a/src/WebRequest.cpp
+++ b/src/WebRequest.cpp
@@ -202,7 +202,7 @@ void AsyncWebServerRequest::_removeNotInterestingHeaders(){
 void AsyncWebServerRequest::_onPoll(){
   //os_printf("p\n");
   if (_parseState == PARSE_REQ_QUEUED) {
-    _server->_processQueue();
+    _server->processQueue();
   } else if(_response != NULL && _client != NULL && _client->canSend() && !_response->_finished()){
     _response->_ack(this, 0, 0);
   }
@@ -606,7 +606,7 @@ void AsyncWebServerRequest::_requestReady() {
     DEBUG_PRINTFP("(%d) WR handler ready %s", (intptr_t) this, url().c_str());
     if(_handler) {
       _parseState = PARSE_REQ_QUEUED;
-      _server->_processQueue();
+      _server->processQueue();
     }
     else {
       _parseState = PARSE_REQ_END;

--- a/src/WebResponseImpl.h
+++ b/src/WebResponseImpl.h
@@ -26,8 +26,7 @@
 #undef min
 #undef max
 #endif
-#include <vector>
-#include "default_init_allocator.h"
+#include "DynamicBuffer.h"
 // It is possible to restore these defines, but one can use _min and _max instead. Or std::min, std::max.
 
 class AsyncBasicResponse: public AsyncWebServerResponse {
@@ -47,7 +46,7 @@ class AsyncAbstractResponse: public AsyncWebServerResponse {
     // This is inefficient with vector, but if we use some other container, 
     // we won't be able to access it as contiguous array of bytes when reading from it,
     // so by gaining performance in one place, we'll lose it in another.
-    std::vector<uint8_t, default_init_allocator<uint8_t>> _packet, _cache;
+    Walkable<DynamicBuffer> _packet, _cache;
     size_t _readDataFromCacheOrContent(uint8_t* data, const size_t len);
     size_t _fillBufferAndProcessTemplates(uint8_t* buf, size_t maxLen);
   protected:

--- a/src/WebResponses.cpp
+++ b/src/WebResponses.cpp
@@ -18,6 +18,8 @@
   License along with this library; if not, write to the Free Software
   Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 */
+
+#include <string.h>
 #include "ESPAsyncWebServer.h"
 #include "WebResponseImpl.h"
 #include "cbuf.h"
@@ -35,16 +37,6 @@
 #endif
 // When looking up available memory, leave some slack
 #define BLOCK_SIZE_SLACK 128
-
-// Since ESP8266 does not link memchr by default, here's its implementation.
-void* memchr(void* ptr, int ch, size_t count)
-{
-  unsigned char* p = static_cast<unsigned char*>(ptr);
-  while(count--)
-    if(*p++ == static_cast<unsigned char>(ch))
-      return --p;
-  return nullptr;
-}
 
 
 /*

--- a/src/WebResponses.cpp
+++ b/src/WebResponses.cpp
@@ -369,17 +369,17 @@ size_t AsyncAbstractResponse::_ack(AsyncWebServerRequest *request, size_t len, u
         do { 
           dealloc_vector(_packet);
           outLen = std::min(outLen, max_block_size);
-          _packet.realloc(outLen);
+          _packet.reallocate(outLen);
           max_block_size = ESP.getMaxFreeBlockSize() - 128;
           DEBUG_PRINTFP("(%d) Checking %d vs %d\n", (intptr_t)this, outLen, max_block_size);
         } while (max_block_size < outLen);
       } else {
-        _packet.realloc(outLen);
+        _packet.reallocate(outLen);
       }
     }
 #else
     //Serial.printf("[%u] %d/%d -> %d\n", (unsigned) millis(),  ESP.getMaxAllocHeap(), ESP.getFreeHeap(), outLen);
-    _packet.realloc(outLen);
+    _packet.reallocate(outLen);
 #endif
     
     if(_chunked){      

--- a/src/WebServer.cpp
+++ b/src/WebServer.cpp
@@ -244,3 +244,16 @@ void AsyncWebServer::_dequeue(AsyncWebServerRequest *request){
   }
 
 }
+
+void AsyncWebServer::dumpStatus() {    
+    Serial.println(F("Web server status:"));
+    auto end = _requestQueue.end();
+    for(auto it = _requestQueue.begin(); it != end; ++it) {
+      Serial.printf_P(PSTR(" Request %d, state %d"), (intptr_t) *it, (*it)->_parseState);
+      if ((*it)->_response) {
+        auto r = (*it)->_response;
+        Serial.printf_P(PSTR(" -- Response %d, state %d, [%d %d - %d %d %d]"), (intptr_t) r, r->_state, r->_headLength, r->_contentLength, r->_sentLength, r->_ackedLength, r->_writtenLength);
+      }
+      Serial.println();
+    }
+}

--- a/src/WebServer.cpp
+++ b/src/WebServer.cpp
@@ -22,7 +22,7 @@
 #include "WebHandlerImpl.h"
 
 #ifdef ASYNCWEBSERVER_DEBUG_TRACE
-#define DEBUG_PRINTFP(fmt, ...) Serial.printf_P(PSTR("[%d]" fmt), millis(), ##__VA_ARGS__)
+#define DEBUG_PRINTFP(fmt, ...) Serial.printf_P(PSTR("[%d]" fmt), (unsigned) millis(), ##__VA_ARGS__)
 #else
 #define DEBUG_PRINTFP(...)
 #endif

--- a/src/WebServer.cpp
+++ b/src/WebServer.cpp
@@ -68,7 +68,7 @@ bool ON_AP_FILTER(AsyncWebServerRequest *request) {
 
 
 static bool minimal_send_503(AsyncClient* c) {
-    const static char msg[] PROGMEM = "HTTP/1.1 503 Service Unavailable\r\n\r\n";
+    const static char msg[] PROGMEM = "HTTP/1.1 503 Service Unavailable\r\nConnection: close\r\n";
 #ifdef PROGMEM  
     char msg_stack[sizeof(msg)];  // stack, so we can pull it out of flash memory
     memcpy_P(msg_stack, msg, sizeof(msg));
@@ -151,7 +151,10 @@ AsyncWebServer::AsyncWebServer(IPAddress addr, uint16_t port, const AsyncWebServ
       c->onAck([](void *, AsyncClient* rc, size_t s, uint32_t ){  
         rc->close(true);        
       });
-      minimal_send_503(c);
+      c->onData([](void*, AsyncClient* rc, void*, size_t){
+        rc->onData({});
+        minimal_send_503(rc);        
+      });      
       return;
     }
 

--- a/src/WebServer.cpp
+++ b/src/WebServer.cpp
@@ -245,7 +245,7 @@ void AsyncWebServer::reset(){
   }
 }
 
-void AsyncWebServer::_processQueue() {  
+void AsyncWebServer::processQueue() {  
   // Consider the state of the requests in the queue.
   // Requests in STATE_END have already been handled; we can assume any heap they need has already been allocated.
   // Requests in STATE_QUEUED are pending.  Each iteration we consider the first one.
@@ -288,7 +288,7 @@ void AsyncWebServer::_processQueue() {
 void AsyncWebServer::_dequeue(AsyncWebServerRequest *request){
   DEBUG_PRINTFP("Removing %d from queue\n", (intptr_t) request);
   _requestQueue.remove(request);
-  _processQueue();
+  processQueue();
 }
 
 void AsyncWebServer::dumpStatus() {    

--- a/src/WebServer.cpp
+++ b/src/WebServer.cpp
@@ -381,15 +381,18 @@ void AsyncWebServer::dumpStatus() {
   {
     guard();  
     for(const auto& entry: _requestQueue) {
-      buf_p = append_vprintf_P(buf_p, end, PSTR(" Request %d, state %d"), (intptr_t) entry, entry->_parseState);
+      buf_p = append_vprintf_P(buf_p, end, PSTR("\n- Request %d, state %d"), (intptr_t) entry, entry->_parseState);
       if (entry->_response) {
         auto r = entry->_response;
         buf_p = append_vprintf_P(buf_p, end, PSTR(" -- Response %d, state %d, [%d %d - %d %d %d]"), (intptr_t) r, r->_state, r->_headLength, r->_contentLength, r->_sentLength, r->_ackedLength, r->_writtenLength);
       }
-      buf_p = append_vprintf_P(buf_p, end, PSTR("\n"));
     }
   }
   buf[sizeof(buf)-1] = 0; // just in case
-  Serial.println(F("Web server status:"));
-  Serial.print(buf);
+  Serial.print(F("Web server status:"));
+  if (buf[0]) {
+    Serial.println(buf);
+  } else {
+    Serial.println(F(" Idle"));
+  }
 }

--- a/src/WebServer.cpp
+++ b/src/WebServer.cpp
@@ -144,12 +144,12 @@ AsyncWebServer::AsyncWebServer(IPAddress addr, uint16_t port, const AsyncWebServ
       // Don't even allocate anything we can avoid.  Tell the client we're in trouble with a static response.
       DEBUG_PRINTFP("*** Rejecting client %d (%d): %d, %d\n", (intptr_t) c, c->getRemotePort(), _requestQueue.length(), ESP.getFreeHeap());
       c->setNoDelay(true);
-      c->onDisconnect([](void*r, AsyncClient* c){
-        DEBUG_PRINTFP("*** Client %d (%d) disconnected\n", (intptr_t)c, c->getRemotePort());
-        delete c;  // There is almost certainly something wrong with this - it's not OK to delete a function object while it's running
+      c->onDisconnect([](void*r, AsyncClient* rc){
+        DEBUG_PRINTFP("*** Client %d (%d) disconnected\n", (intptr_t)rc, rc->getRemotePort());
+        delete rc;  // There is almost certainly something wrong with this - it's not OK to delete a function object while it's running
       });
-      c->onAck([](void *, AsyncClient* c, size_t s, uint32_t ){  
-        c->close(true);        
+      c->onAck([](void *, AsyncClient* rc, size_t s, uint32_t ){  
+        rc->close(true);        
       });
       minimal_send_503(c);
       return;

--- a/src/WebServer.cpp
+++ b/src/WebServer.cpp
@@ -373,7 +373,7 @@ static char* append_vprintf_P(char* buf, char* end, const char* /*PROGMEM*/ fmt,
   return (needed >= max) ? end-1 : buf + needed;
 }
 
-void AsyncWebServer::dumpStatus() {
+void AsyncWebServer::printStatus(Print& dest) {
   char buf[1024];
   char* buf_p = buf;
   char* end = &buf[sizeof(buf)];
@@ -381,18 +381,18 @@ void AsyncWebServer::dumpStatus() {
   {
     guard();  
     for(const auto& entry: _requestQueue) {
-      buf_p = append_vprintf_P(buf_p, end, PSTR("\n- Request %d, state %d"), (intptr_t) entry, entry->_parseState);
+      buf_p = append_vprintf_P(buf_p, end, PSTR("\n- Request %X, state %d"), (intptr_t) entry, entry->_parseState);
       if (entry->_response) {
         auto r = entry->_response;
-        buf_p = append_vprintf_P(buf_p, end, PSTR(" -- Response %d, state %d, [%d %d - %d %d %d]"), (intptr_t) r, r->_state, r->_headLength, r->_contentLength, r->_sentLength, r->_ackedLength, r->_writtenLength);
+        buf_p = append_vprintf_P(buf_p, end, PSTR(" -- Response %X, state %d, [%d %d - %d %d %d]"), (intptr_t) r, r->_state, r->_headLength, r->_contentLength, r->_sentLength, r->_ackedLength, r->_writtenLength);
       }
     }
   }
   buf[sizeof(buf)-1] = 0; // just in case
-  Serial.print(F("Web server status:"));
+  dest.print(F("Web server status:"));
   if (buf[0]) {
-    Serial.println(buf);
+    dest.println(buf);
   } else {
-    Serial.println(F(" Idle"));
+    dest.println(F(" Idle"));
   }
 }

--- a/src/WebServer.cpp
+++ b/src/WebServer.cpp
@@ -259,6 +259,7 @@ void AsyncWebServer::processQueue() {
   // We always allow one request, regardless of heap state.
   guard();
 
+#ifdef ASYNCWEBSERVER_DEBUG_TRACE
   {
     size_t count = 0, active = 0, queued = 0;
     for(auto element: _requestQueue) {
@@ -268,6 +269,7 @@ void AsyncWebServer::processQueue() {
     }
     DEBUG_PRINTFP("Queue: %d entries, %d running, %d queued\n", count, active, queued);
   }
+#endif  
 
   do { 
     auto heap_ok = ESP.getFreeHeap() >= (_reqHeapUsage + _minHeap);    

--- a/src/WebServer.cpp
+++ b/src/WebServer.cpp
@@ -244,8 +244,14 @@ void AsyncWebServer::_dequeue(AsyncWebServerRequest *request){
       ++i, ++it;
     }
   }
-
 }
+
+void AsyncWebServer::_defer(AsyncWebServerRequest *request) {
+  // TODO: improve efficiency
+  _dequeue(request);
+  _requestQueue.add(request);
+}
+
 
 void AsyncWebServer::dumpStatus() {    
     Serial.println(F("Web server status:"));

--- a/src/WebServer.cpp
+++ b/src/WebServer.cpp
@@ -58,11 +58,11 @@ AsyncWebServer::AsyncWebServer(IPAddress addr, uint16_t port, size_t parallelReq
         || (ESP.getFreeHeap() < ASYNCWEBSERVER_MINIMUM_HEAP))
     {
       // Don't even allocate anything we can avoid.  Tell the client we're in trouble with a static response.
+      c->onAck([](void *, AsyncClient* c, size_t , uint32_t ){  c->close(); });
       const static char msg_progmem[] PROGMEM = "HTTP/1.1 503 Service Unavailable\r\n\r\n";
       char msg_stack[sizeof(msg_progmem)];  // stack, so we can pull it out of flash memory
       memcpy_P(msg_stack, msg_progmem, sizeof(msg_stack));
       c->write(msg_stack, sizeof(msg_stack));
-      c->close();
       return;
     }
     

--- a/src/WebServer.cpp
+++ b/src/WebServer.cpp
@@ -310,6 +310,18 @@ void AsyncWebServer::reset(){
   }
 }
 
+size_t AsyncWebServer::numClients(){
+  guard();
+  return _requestQueue.length();
+}
+
+size_t AsyncWebServer::queueLength(){
+  guard();
+  size_t count = 0U;
+  for(const auto& client: _requestQueue) { if (client->_parseState >= 200) ++count; };
+  return count;
+}
+
 void AsyncWebServer::processQueue(){  
   // Consider the state of the requests in the queue.
   // Requests in STATE_END have already been handled; we can assume any heap they need has already been allocated.

--- a/src/WebServer.cpp
+++ b/src/WebServer.cpp
@@ -303,7 +303,11 @@ void AsyncWebServer::_dequeue(AsyncWebServerRequest *request){
   processQueue();
 }
 
-void AsyncWebServer::dumpStatus() {    
+void AsyncWebServer::dumpStatus() {
+  #ifdef ESP8266
+  // This can't be made safe - the printf_P() function permits yield.
+  return;
+  #endif
   guard();
   Serial.println(F("Web server status:"));
   auto end = _requestQueue.end();

--- a/src/WebServer.cpp
+++ b/src/WebServer.cpp
@@ -310,7 +310,7 @@ void AsyncWebServer::reset(){
   }
 }
 
-void AsyncWebServer::processQueue() {  
+void AsyncWebServer::processQueue(){  
   // Consider the state of the requests in the queue.
   // Requests in STATE_END have already been handled; we can assume any heap they need has already been allocated.
   // Requests in STATE_QUEUED are pending.  Each iteration we consider the first one.
@@ -377,7 +377,12 @@ void AsyncWebServer::_dequeue(AsyncWebServerRequest *request){
   processQueue();
 }
 
-static char* append_vprintf_P(char* buf, char* end, const char* /*PROGMEM*/ fmt, ...) {
+void AsyncWebServer::setQueueLimits(const AsyncWebServerQueueLimits& limits) {
+  guard();
+  _queueLimits = limits;
+}
+
+static char* append_vprintf_P(char* buf, char* end, const char* /*PROGMEM*/ fmt, ...){
   va_list argp;
   va_start(argp, fmt);
   const auto max = end-buf;
@@ -386,7 +391,7 @@ static char* append_vprintf_P(char* buf, char* end, const char* /*PROGMEM*/ fmt,
   return (needed >= max) ? end-1 : buf + needed;
 }
 
-void AsyncWebServer::printStatus(Print& dest) {
+void AsyncWebServer::printStatus(Print& dest){
   char buf[1024];
   char* buf_p = buf;
   char* end = &buf[sizeof(buf)];

--- a/src/WebServer.cpp
+++ b/src/WebServer.cpp
@@ -411,7 +411,7 @@ void AsyncWebServer::printStatus(Print& dest){
   {
     guard();  
     for(const auto& entry: _requestQueue) {
-      buf_p = append_vprintf_P(buf_p, end, PSTR("\n- Request %X, state %d"), (intptr_t) entry, entry->_parseState);
+      buf_p = append_vprintf_P(buf_p, end, PSTR("\n- Request %X [%X], state %d"), (intptr_t) entry, (intptr_t) entry->_client, entry->_parseState);
       if (entry->_response) {
         auto r = entry->_response;
         buf_p = append_vprintf_P(buf_p, end, PSTR(" -- Response %X, state %d, [%d %d - %d %d %d]"), (intptr_t) r, r->_state, r->_headLength, r->_contentLength, r->_sentLength, r->_ackedLength, r->_writtenLength);


### PR DESCRIPTION
Add a request queue to AsyncWebServer with limits on queue size and available memory.  This permits web servers to manage resource usage, so as to avoid crashing when overloaded.   Requests that cannot be queued will be served a 503 response (unless the system is truly out of resources, at which point the connections are simply summarily closed.)

The queuing feature also permits handler functions to `defer()`, indicating that some other resource is contended on, and the request cannot be immediately serviced.  When called, the handler will be re-executed (if resources permit) when the queue is next pumped.

The queue is pumped any time a new request is ready to handle, when a request is destructed, and periodically in poll() callbacks.