### PR TITLE
Improve AsyncResponseStream

### DIFF
--- a/src/ESPAsyncWebServer.h
+++ b/src/ESPAsyncWebServer.h
@@ -249,7 +249,7 @@ class AsyncWebServerRequest {
     AsyncWebServerResponse *beginResponse(Stream &stream, const String& contentType, size_t len, AwsTemplateProcessor callback=nullptr);
     AsyncWebServerResponse *beginResponse(const String& contentType, size_t len, AwsResponseFiller callback, AwsTemplateProcessor templateCallback=nullptr);
     AsyncWebServerResponse *beginChunkedResponse(const String& contentType, AwsResponseFiller callback, AwsTemplateProcessor templateCallback=nullptr);
-    AsyncResponseStream *beginResponseStream(const String& contentType, size_t bufferSize=1460);
+    AsyncResponseStream *beginResponseStream(const String& contentType, size_t bufferSize=TCP_MSS);
     AsyncWebServerResponse *beginResponse_P(int code, const String& contentType, const uint8_t * content, size_t len, AwsTemplateProcessor callback=nullptr);
     AsyncWebServerResponse *beginResponse_P(int code, const String& contentType, PGM_P content, AwsTemplateProcessor callback=nullptr);
 

--- a/src/WebResponseImpl.h
+++ b/src/WebResponseImpl.h
@@ -119,11 +119,11 @@ class AsyncProgmemResponse: public AsyncAbstractResponse {
     virtual size_t _fillBuffer(uint8_t *buf, size_t maxLen) override;
 };
 
-class cbuf;
-
 class AsyncResponseStream: public AsyncAbstractResponse, public Print {
   private:
-    cbuf *_content;
+    DynamicBufferList _content;
+    DynamicBufferListPrint _print;
+    size_t _offset;
   public:
     AsyncResponseStream(const String& contentType, size_t bufferSize);
     ~AsyncResponseStream();

--- a/src/WebResponseImpl.h
+++ b/src/WebResponseImpl.h
@@ -28,6 +28,8 @@
 #endif
 #include <vector>
 #include "default_init_allocator.h"
+#include "DynamicBuffer.h"
+
 // It is possible to restore these defines, but one can use _min and _max instead. Or std::min, std::max.
 
 class AsyncBasicResponse: public AsyncWebServerResponse {

--- a/src/WebResponseImpl.h
+++ b/src/WebResponseImpl.h
@@ -125,7 +125,7 @@ class AsyncResponseStream: public AsyncAbstractResponse, public Print {
     DynamicBufferListPrint _print;
     size_t _offset;
   public:
-    AsyncResponseStream(const String& contentType, size_t bufferSize);
+    AsyncResponseStream(const String& contentType, size_t bufferSize=TCP_MSS);
     ~AsyncResponseStream();
     bool _sourceValid() const { return (_state < RESPONSE_END); }
     virtual size_t _fillBuffer(uint8_t *buf, size_t maxLen) override;


### PR DESCRIPTION
Leverage DynamicBufferList to provide a linear rope allocator, ensuring small allocations and no copies when new allocations are needed.